### PR TITLE
Feature: Cumulative toggle

### DIFF
--- a/exampleVault/movies.base
+++ b/exampleVault/movies.base
@@ -13,6 +13,7 @@ views:
     min-y-override: ""
     max-y-override: ""
     label-property: note.original_title
+    cumulative-y: false
   - type: chart-bar
     name: Release year
     filters:
@@ -22,3 +23,17 @@ views:
       - formula.One
     x: formula.Release Year
     show-labels: false
+    cumulative-y: false
+  - type: chart-line
+    name: Cumulative length vs Release year
+    order:
+      - votes
+      - duration
+      - avg_vote
+    sort:
+      - property: formula.Release Year
+        direction: ASC
+    x: formula.Release Year
+    cumulative-y: true
+    sync-y-axes: false
+    multi-chart-mode: Separate by property

--- a/packages/obsidian/src/ChartView.ts
+++ b/packages/obsidian/src/ChartView.ts
@@ -21,6 +21,7 @@ export const CHART_SETTINGS = {
 	SHOW_LABELS: 'show-labels',
 	MULTI_CHART: 'multi-chart-mode',
 	SYNC_Y_AXES: 'sync-y-axes',
+	CUMULATIVE_Y: 'cumulative-y',
 	MIN_Y_OVERRIDE: 'min-y-override',
 	MAX_Y_OVERRIDE: 'max-y-override',
 	LABEL_PROP: 'label-property',
@@ -123,7 +124,8 @@ export class ChartView extends BasesView {
 
 		const data: ProcessedData[] = [];
 		const groupBySet = this.data.groupedData.map(g => g.key?.toString()).filter(k => k != null);
-
+		const cumulativeY = Boolean(this.config.get(CHART_SETTINGS.CUMULATIVE_Y));
+		console.log(propertyOrder.length)
 		for (const group of this.data?.groupedData ?? []) {
 			const groupKey = group.key?.toString();
 			let groupIndex: number;
@@ -132,9 +134,25 @@ export class ChartView extends BasesView {
 			} else {
 				groupIndex = groupBySet.indexOf(groupKey);
 			}
-
+			const numProperties = propertyOrder.length
+			let previous_y = new Array(numProperties).fill(0);
 			for (const entry of group.entries) {
+				
 				const processedEntry = this.processEntry(entry, xField, propertyOrder, groupIndex, mode);
+				// Iterate over each data point in processedEntry, cumulate by group
+				for (const dataPoint of processedEntry) { 
+					if (cumulativeY) {
+						let propIndex;
+						if (mode == MultiChartMode.GROUP) {
+							propIndex = dataPoint.groupIndex
+						} else {
+							propIndex = dataPoint.chartIndex
+						}
+						dataPoint.y += previous_y[propIndex]; 
+						previous_y[propIndex] = dataPoint.y;
+					}
+				}
+
 				data.push(...processedEntry);
 			}
 		}
@@ -151,7 +169,7 @@ export class ChartView extends BasesView {
 			const x = entry.getValue(xField);
 			const xValue = parseValueAsX(x);
 			const labelProp = this.config.getAsPropertyId(CHART_SETTINGS.LABEL_PROP);
-
+		
 			if (xValue === null) {
 				return [];
 			}
@@ -245,6 +263,12 @@ export class ChartView extends BasesView {
 				displayName: 'Sync Y axes',
 				type: 'toggle',
 				key: CHART_SETTINGS.SYNC_Y_AXES,
+				default: false,
+			},
+			{
+				displayName: 'Cumulative Y',
+				type: 'toggle',
+				key: CHART_SETTINGS.CUMULATIVE_Y,
 				default: false,
 			},
 			{


### PR DESCRIPTION
Add toggle to change the y axis to a cumulative one. 
Order will follow the sorting variable.
Example added in `movies.base`.

Use case: I have a list of tasks, each task is a markdown file. Each file has the properties "resolvedDate" and "timeSpent". I want to plot a chart with cumulative time spent by time.