### PR TITLE
fix: line chart point ordering

### DIFF
--- a/exampleVault/data-points.base
+++ b/exampleVault/data-points.base
@@ -1,0 +1,9 @@
+views:
+  - type: chart-line
+    name: line-chart
+    filters:
+      and:
+        - type == "data-point"
+    order:
+      - valY
+    x: note.Date

--- a/exampleVault/data-points/2011-11-09.md
+++ b/exampleVault/data-points/2011-11-09.md
@@ -1,0 +1,5 @@
+---
+date: 2011-11-09
+type: data-point
+valY: 27
+---

--- a/exampleVault/data-points/2012-11-09.md
+++ b/exampleVault/data-points/2012-11-09.md
@@ -1,0 +1,5 @@
+---
+date: 2012-11-09
+type: data-point
+valY: 26
+---

--- a/exampleVault/data-points/2013-06-21.md
+++ b/exampleVault/data-points/2013-06-21.md
@@ -1,0 +1,5 @@
+---
+date: 2013-06-21
+type: data-point
+valY: 28
+---

--- a/exampleVault/data-points/2013-12-08.md
+++ b/exampleVault/data-points/2013-12-08.md
@@ -1,0 +1,5 @@
+---
+date: 2013-12-08
+type: data-point
+valY: 25
+---

--- a/exampleVault/data-points/2014-07-01.md
+++ b/exampleVault/data-points/2014-07-01.md
@@ -1,0 +1,5 @@
+---
+date: 2014-07-01
+type: data-point
+valY: 31
+---

--- a/exampleVault/data-points/2015-02-28.md
+++ b/exampleVault/data-points/2015-02-28.md
@@ -1,0 +1,5 @@
+---
+date: 2015-02-28
+type: data-point
+valY: 55
+---

--- a/exampleVault/data-points/2015-12-18.md
+++ b/exampleVault/data-points/2015-12-18.md
@@ -1,0 +1,5 @@
+---
+date: 2015-12-18
+type: data-point
+valY: 44
+---

--- a/exampleVault/data-points/2016-10-12.md
+++ b/exampleVault/data-points/2016-10-12.md
@@ -1,0 +1,5 @@
+---
+date: 2016-10-12
+type: data-point
+valY: 59
+---

--- a/exampleVault/data-points/2018-07-04.md
+++ b/exampleVault/data-points/2018-07-04.md
@@ -1,0 +1,5 @@
+---
+date: 2018-07-04
+type: data-point
+valY: 65
+---

--- a/exampleVault/data-points/2018-08-28.md
+++ b/exampleVault/data-points/2018-08-28.md
@@ -1,0 +1,5 @@
+---
+date: 2018-08-28
+type: data-point
+valY: 83
+---

--- a/exampleVault/data-points/2018-10-09.md
+++ b/exampleVault/data-points/2018-10-09.md
@@ -1,0 +1,5 @@
+---
+date: 2018-10-09
+type: data-point
+valY: 196
+---

--- a/exampleVault/data-points/2018-11-07.md
+++ b/exampleVault/data-points/2018-11-07.md
@@ -1,0 +1,5 @@
+---
+date: 2018-11-07
+type: data-point
+valY: 142
+---

--- a/exampleVault/data-points/2019-05-09.md
+++ b/exampleVault/data-points/2019-05-09.md
@@ -1,0 +1,5 @@
+---
+date: 2019-05-09
+type: data-point
+valY: 83
+---

--- a/exampleVault/data-points/2019-11-21.md
+++ b/exampleVault/data-points/2019-11-21.md
@@ -1,0 +1,5 @@
+---
+date: 2019-11-21
+type: data-point
+valY: 75
+---

--- a/exampleVault/data-points/2020-07-21.md
+++ b/exampleVault/data-points/2020-07-21.md
@@ -1,0 +1,5 @@
+---
+date: 2020-07-21
+type: data-point
+valY: 116
+---

--- a/exampleVault/data-points/2021-01-29.md
+++ b/exampleVault/data-points/2021-01-29.md
@@ -1,0 +1,5 @@
+---
+date: 2021-01-29
+type: data-point
+valY: 83
+---

--- a/exampleVault/data-points/2022-01-31.md
+++ b/exampleVault/data-points/2022-01-31.md
@@ -1,0 +1,5 @@
+---
+date: 2022-01-31
+type: data-point
+valY: 94
+---

--- a/exampleVault/data-points/2022-04-06.md
+++ b/exampleVault/data-points/2022-04-06.md
@@ -1,0 +1,5 @@
+---
+date: 2022-04-06
+type: data-point
+valY: 167
+---

--- a/exampleVault/data-points/2022-06-17.md
+++ b/exampleVault/data-points/2022-06-17.md
@@ -1,0 +1,5 @@
+---
+date: 2022-06-17
+type: data-point
+valY: 118
+---

--- a/exampleVault/data-points/2022-09-15.md
+++ b/exampleVault/data-points/2022-09-15.md
@@ -1,0 +1,5 @@
+---
+date: 2022-09-15
+type: data-point
+valY: 104
+---

--- a/exampleVault/data-points/2022-11-09.md
+++ b/exampleVault/data-points/2022-11-09.md
@@ -1,0 +1,5 @@
+---
+date: 2022-11-09
+type: data-point
+valY: 151
+---

--- a/exampleVault/data-points/2023-01-18.md
+++ b/exampleVault/data-points/2023-01-18.md
@@ -1,0 +1,5 @@
+---
+date: 2023-01-18
+type: data-point
+valY: 107
+---

--- a/exampleVault/data-points/2023-04-05.md
+++ b/exampleVault/data-points/2023-04-05.md
@@ -1,0 +1,5 @@
+---
+date: 2023-04-05
+type: data-point
+valY: 59
+---

--- a/exampleVault/data-points/2023-06-07.md
+++ b/exampleVault/data-points/2023-06-07.md
@@ -1,0 +1,5 @@
+---
+date: 2023-06-07
+type: data-point
+valY: 121
+---

--- a/exampleVault/data-points/2024-02-28.md
+++ b/exampleVault/data-points/2024-02-28.md
@@ -1,0 +1,5 @@
+---
+date: 2024-02-28
+type: data-point
+valY: 123
+---

--- a/exampleVault/data-points/2024-05-29.md
+++ b/exampleVault/data-points/2024-05-29.md
@@ -1,0 +1,5 @@
+---
+date: 2024-05-29
+type: data-point
+valY: 107
+---

--- a/exampleVault/data-points/2024-10-17.md
+++ b/exampleVault/data-points/2024-10-17.md
@@ -1,0 +1,5 @@
+---
+date: 2024-10-17
+type: data-point
+valY: 136
+---

--- a/exampleVault/data-points/2025-02-25 (2).md
+++ b/exampleVault/data-points/2025-02-25 (2).md
@@ -1,0 +1,5 @@
+---
+date: 2025-02-25
+type: data-point
+valY: 122
+---

--- a/exampleVault/data-points/2025-02-25.md
+++ b/exampleVault/data-points/2025-02-25.md
@@ -1,0 +1,5 @@
+---
+date: 2025-02-25
+type: data-point
+valY: 122
+---

--- a/exampleVault/data-points/2025-05-09 (2).md
+++ b/exampleVault/data-points/2025-05-09 (2).md
@@ -1,0 +1,5 @@
+---
+date: 2025-05-09
+type: data-point
+valY: 64
+---

--- a/exampleVault/data-points/2025-05-09.md
+++ b/exampleVault/data-points/2025-05-09.md
@@ -1,0 +1,5 @@
+---
+date: 2025-05-09
+type: data-point
+valY: 64
+---

--- a/exampleVault/data-points/2025-10-21 (2).md
+++ b/exampleVault/data-points/2025-10-21 (2).md
@@ -1,0 +1,5 @@
+---
+date: 2025-10-21
+type: data-point
+valY: 106
+---

--- a/exampleVault/data-points/2025-10-21.md
+++ b/exampleVault/data-points/2025-10-21.md
@@ -1,0 +1,5 @@
+---
+date: 2025-10-21
+type: data-point
+valY: 106
+---

--- a/exampleVault/data-points/2026-03-05.md
+++ b/exampleVault/data-points/2026-03-05.md
@@ -1,0 +1,5 @@
+---
+date: 2026-03-05
+type: data-point
+valY: 97
+---

--- a/packages/obsidian/src/ChartData.ts
+++ b/packages/obsidian/src/ChartData.ts
@@ -225,9 +225,22 @@ export function emptyDataWrapper(view: ChartView): DataWrapper {
 
 export function sortDataByGroup(data: ProcessedData[]): ProcessedData[] {
 	return data.sort((a, b) => {
-		if (a.groupIndex != null && b.groupIndex != null) {
+		if (a.groupIndex !== b.groupIndex) {
 			return a.groupIndex - b.groupIndex;
 		}
-		return 0;
+		return compareX(a.x, b.x);
 	});
+}
+
+function compareX(a: number | Date | string, b: number | Date | string): number {
+	if (a instanceof Date && b instanceof Date) {
+		return a.getTime() - b.getTime();
+	}
+	if (typeof a === 'number' && typeof b === 'number') {
+		return a - b;
+	}
+	if (typeof a === 'string' && typeof b === 'string') {
+		return a.localeCompare(b);
+	}
+	return 0;
 }


### PR DESCRIPTION
Sort points by x within each group in sortDataByGroup. groupedData from BasesQueryResult is not guaranteed to be presorted, and svelteplot's Line draws the polyline in array order, so without an x-sort the line could connect points out of chronological order.

Adds an example data-points base/dataset to reproduce.