### PR TITLE
fix: remove bases-chart-view class on unload to avoid leaking flex layout into other views

### DIFF
--- a/exampleVault/penguins.base
+++ b/exampleVault/penguins.base
@@ -15,3 +15,18 @@ views:
     x: note.culmen_length_mm
     multi-chart-mode: Separate by property
     sync-y-axes: false
+  - type: table
+    name: Table
+    filters:
+      and:
+        - file.folder == "penguins"
+    order:
+      - file.name
+      - species
+      - sex
+      - island
+      - culmen_depth_mm
+      - culmen_length_mm
+      - flipper_length_mm
+    columnSize:
+      note.flipper_length_mm: 195

--- a/packages/obsidian/src/ChartView.ts
+++ b/packages/obsidian/src/ChartView.ts
@@ -94,6 +94,7 @@ export class ChartView extends BasesView {
 	}
 
 	onunload(): void {
+		this.scrollEl.removeClass('bases-chart-view');
 		if (this.svelteComponent) {
 			void unmount(this.svelteComponent);
 		}


### PR DESCRIPTION
When switching from a chart view to another view (e.g. table) of the same Base, Obsidian reuses the same scrollEl. The plugin was adding the `bases-chart-view` class on load but never removing it, so the `display: flex` rule from styles.css kept being applied to the table container, causing rows to overlap the header.

Also adds a Table view to the penguins example base so this regression is easy to reproduce in exampleVault.